### PR TITLE
(Feature) Install bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-RUN gem install mdl
+RUN gem install mdl bundler
 
 RUN pip install awscli proselint
 


### PR DESCRIPTION
* We have tests (rake tasks) that require running `bundle install` to install the
dependencies.