### PR TITLE
Add build-essential

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
     python \
     ruby \
     ruby-dev \
+    build-essential \
     python-pip \
     python-setuptools \
     wget \


### PR DESCRIPTION
Because we are now building gems which need make we should install the
build-essential metapackage