### PR TITLE
Update the system rubygems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
+RUN gem update --system --no-ri --no-rdoc
 RUN gem install mdl bundler
 
 RUN pip install awscli proselint yamllint


### PR DESCRIPTION
This is so bundler doesnt error with

```
/usr/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
   from /usr/lib/ruby/2.5.0/rubygems.rb:308:in `activate_bin_path'
   from /usr/local/bin/bundle:23:in `<main>'
```

as suggested by https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html