### PR TITLE
Stop setting versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ RUN pip install awscli proselint yamllint
 RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
     && ln -s ~/.rbenv/bin/* /usr/local/bin
 
+RUN git clone https://github.com/rbenv/rbenv-default-gems.git "$(rbenv root)/plugins/rbenv-default-gems" \
+    && echo "bundler" >> "$(rbenv root)/default-gems" \
+    && echo "mdl" >> "$(rbenv root)/default-gems"
+
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
     && ln -s ~/.tfenv/bin/* /usr/local/bin
 RUN tfenv install 0.11.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
     && ln -s ~/.tfenv/bin/* /usr/local/bin
 
 RUN mkdir -p /tmp/tflint \
-    && wget https://github.com/wata727/tflint/releases/download/v0.8.0/tflint_linux_amd64.zip -O /tmp/tflint/tflint.zip\
-    && unzip /tmp/tflint/tflint.zip -d /tmp/tflint\
-    && mv /tmp/tflint/tflint /usr/local/bin/tflint\
+    && wget https://github.com/wata727/tflint/releases/download/v0.16.2/tflint_linux_amd64.zip -O /tmp/tflint/tflint.zip \
+    && unzip /tmp/tflint/tflint.zip -d /tmp/tflint \
+    && mv /tmp/tflint/tflint /usr/local/bin/tflint \
     && rm -rf /tmp/tflint
 
 # rewrite url schema for GitHub URLs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     git \
     python \
-    ruby \
-    ruby-dev \
     build-essential \
     python-pip \
     python-setuptools \
@@ -18,12 +16,11 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-RUN gem update --system --no-ri --no-rdoc
-RUN gem install mdl bundler
-
 RUN pip install awscli proselint yamllint
 
-# install tfenv and the latest 0.11.4
+RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
+    && ln -s ~/.rbenv/bin/* /usr/local/bin
+
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
     && ln -s ~/.tfenv/bin/* /usr/local/bin
 RUN tfenv install 0.11.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN git clone https://github.com/rbenv/rbenv-default-gems.git "$(rbenv root)/plu
 
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
     && ln -s ~/.tfenv/bin/* /usr/local/bin
-RUN tfenv install 0.11.14
 
 RUN mkdir -p /tmp/tflint \
     && wget https://github.com/wata727/tflint/releases/download/v0.8.0/tflint_linux_amd64.zip -O /tmp/tflint/tflint.zip\


### PR DESCRIPTION
This change will mean that anything using this will need to install their desired versions of Ruby and Terraform using `rbenv` and `tfenv`.