### PR TITLE
Updated to ubuntu Jammy LTS and switched to Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ARG SHELLCHECK_VERSION="v0.9.0"
 ARG RBENV_VERSION="v1.2.0"
@@ -12,13 +12,13 @@ RUN apt-get update \
     groff \
     libreadline-dev \
     libssl-dev \
-    python \
-    python-pip \
-    python-setuptools \
     unzip \
     wget \
     zlib1g-dev \
     jq \
+    python3 \
+    python3-pip \
+    python3-setuptools \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
In order to support testing against newer versions of `ruby` https://github.com/dxw/dalmatian/pull/539 we ought to update to the `jammy` release of ubuntu which is the latest LTS. `bionic` is now EOL.

As a side effect, `python3` is now the default package available to us